### PR TITLE
Fix duplicate events

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.use(express.json());
 const slackClient = new WebClient(SLACK_ACCESS_TOKEN);
 const EventQueue = createEventQueue();
 
-const handleAppMention = (event) => {
+const handleAppMention = async (event) => {
   try {
     const {
       uploadType,

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const { createEventAdapter } = require('@slack/events-api');
 
 const { postStudyMarkdown } = require('./api');
 const { parseAppMentionText } = require('./utils');
+const { createEventQueue } = require('./utils/event-queue');
 
 const {
   SLACK_ACCESS_TOKEN,
@@ -23,8 +24,9 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 
 const slackClient = new WebClient(SLACK_ACCESS_TOKEN);
+const EventQueue = createEventQueue();
 
-slackEvents.on('app_mention', async (event) => {
+const appMentionEvent = (event) => {
   try {
     const {
       uploadType,
@@ -47,6 +49,10 @@ slackEvents.on('app_mention', async (event) => {
       text: `<@${event.user}> 업데이트에 실패했어요 :baby_chick: :point_right: ${error.message}`,
     });
   }
+};
+
+slackEvents.on('app_mention', async (event) => {
+  EventQueue.set(event);
 });
 
 slackEvents.on('error', console.error);

--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ const handleAppMention = (event) => {
   }
 };
 
-slackEvents.on('app_mention', async (event) => {
+slackEvents.on('app_mention', (event) => {
   EventQueue.set(event);
 
   setTimeout(async () => {

--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ slackEvents.on('app_mention', async (event) => {
   EventQueue.set(event);
 
   setTimeout(async () => {
-    await Promise.all(EventQueue.mapPromise(handleAppMention));
+    await Promise.all(EventQueue.mapEvent(handleAppMention));
   }, 10000);
 });
 

--- a/app.js
+++ b/app.js
@@ -53,6 +53,10 @@ const appMentionEvent = (event) => {
 
 slackEvents.on('app_mention', async (event) => {
   EventQueue.set(event);
+
+  setTimeout(async () => {
+    await Promise.all(EventQueue.mapPromise(appMentionEvent));
+  }, 10000);
 });
 
 slackEvents.on('error', console.error);

--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.use(express.json());
 const slackClient = new WebClient(SLACK_ACCESS_TOKEN);
 const EventQueue = createEventQueue();
 
-const appMentionEvent = (event) => {
+const handleAppMention = (event) => {
   try {
     const {
       uploadType,
@@ -55,7 +55,7 @@ slackEvents.on('app_mention', async (event) => {
   EventQueue.set(event);
 
   setTimeout(async () => {
-    await Promise.all(EventQueue.mapPromise(appMentionEvent));
+    await Promise.all(EventQueue.mapPromise(handleAppMention));
   }, 10000);
 });
 

--- a/app.js
+++ b/app.js
@@ -51,8 +51,14 @@ const handleAppMention = async (event) => {
   }
 };
 
-slackEvents.on('app_mention', (event) => {
+slackEvents.on('app_mention', async (event) => {
   EventQueue.set(event);
+
+  await slackClient.chat.postEphemeral({
+    channel: event.channel,
+    user: event.user,
+    text: '잠시만 기다려주세요!',
+  });
 
   setTimeout(async () => {
     await Promise.all(EventQueue.mapEvent(handleAppMention));

--- a/utils/event-queue.js
+++ b/utils/event-queue.js
@@ -1,0 +1,28 @@
+const createEventQueue = () => {
+  const events = new Map();
+
+  return {
+    has: function (event) {
+      return events.has(event.text);
+    },
+    set: function (event) {
+      if (this.has(event)) return;
+
+      events.set(event.text, event);
+    },
+    mapPromise: function (promiseCallback) {
+      const eventPromises = [];
+
+      events.forEach((event, key) => {
+        eventPromises.push(promiseCallback(event));
+        events.delete(key);
+      });
+
+      return eventPromises;
+    }
+  };
+};
+
+module.exports = {
+  createEventQueue,
+};

--- a/utils/event-queue.js
+++ b/utils/event-queue.js
@@ -10,11 +10,11 @@ const createEventQueue = () => {
 
       events.set(event.text, event);
     },
-    mapPromise: function (promiseCallback) {
+    mapEvent: function (eventHandler) {
       const eventPromises = [];
 
       events.forEach((event, key) => {
-        eventPromises.push(promiseCallback(event));
+        eventPromises.push(eventHandler(event));
         events.delete(key);
       });
 


### PR DESCRIPTION
슬랙 문서를 보니 3초 안에 2xx response가 오지 않으면 실패로 간주하고 3번 더 재시도를 해서 같은 이벤트가 중복으로 처리되는 문제를 해결합니다.

-----

**[해결 방법]**
eventQueue라는 Map을 생성한 후, 이벤트 발생 시 Map에 저장합니다.

만약 evnetQueue에 이미 같은 이벤트가 생성되어있다면 저장하지 않습니다.
(Map에 저장 시 event.text를 키값으로 하여 판별합니다.)

10초 후, evnetQueue에 저장된 이벤트들을 순차적으로 실행하고, 실행된 이벤트는 바로 삭제합니다.

